### PR TITLE
Admins bugfix

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -38,8 +38,8 @@ text-decoration:none;
 
 .admins_index{
 	background-color: #EEEEEEEE;
-	width: 200px;
 	text-align: center;
+  margin-top:1rem;
 }
 
 .thead{

--- a/app/controllers/admins/tests_controller.rb
+++ b/app/controllers/admins/tests_controller.rb
@@ -35,16 +35,14 @@ class Admins::TestsController < ApplicationController
   end
 
   def create
-    #editから来た場合は紐づいているtest_idがある + 少なくとも１問目は初めから存在しているため["0"]を取り出す
+    #editから来た場合は少なくとも１問目は初めから存在しているため["0"][:id]を取り出す。新規であれば保存前なので[:id]=nilになる。
     if params[:test][:details_attributes]["0"][:id].present?
       @test = Test.find(Detail.find(params[:test][:details_attributes]["0"][:id]).test_id)
       @test.update!(tests_params)
 
     else
       @test = Test.new(tests_params)
-      binding.pry
       @test.save!
-      binding.pry
     end
 
     #診断結果の中身が存在しているか確認して、なければdetailから解答順がいくつあるか計算。簡略化するために規則性がないか要検討
@@ -64,7 +62,6 @@ class Admins::TestsController < ApplicationController
       @patterns = ["111","112", "121", "122", "211", "212", "221", "222"]
     end
 
-binding.pry
       #一つの診断結果を複数の解答順で使いまわせるように配列で保存したい
       #苦肉の策：edit共有
       redirect_to edit_admins_test_path(id: @test.id, patterns: @patterns)

--- a/app/controllers/admins/tests_controller.rb
+++ b/app/controllers/admins/tests_controller.rb
@@ -20,6 +20,7 @@ class Admins::TestsController < ApplicationController
     @test = Test.find(params[:id])
     @details = @test.details
     @results = @test.results
+    @categories = Category.all
     if params[:patterns].present?
       @patterns = params[:patterns]
 
@@ -27,43 +28,46 @@ class Admins::TestsController < ApplicationController
     else
       @patterns = []
 
-      #結果に至るパターンを全て@patternsの配列に入れる
+      #結果に至るパターン(解答順)を全て@patternsの配列に入れる
       #このままでは配列の中に複数の配列が入ってるのでflatten!メソッドで配列中に含まれる配列からすべて要素を取り出して、親の配列の中に並べる
       @patterns.push(@results.pluck(:patterns)).flatten!
     end
-    @categories = Category.all
   end
 
   def create
-    @test = Test.new(tests_params)
-    @test.save!
+    #editから来た場合は紐づいているtest_idがある + 少なくとも１問目は初めから存在しているため["0"]を取り出す
+    if params[:test][:details_attributes]["0"][:id].present?
+      @test = Test.find(Detail.find(params[:test][:details_attributes]["0"][:id]).test_id)
+      @test.update!(tests_params)
 
-    #診断結果の中身が存在しているか確認して、なければdetailから解答順がいくつあるか計算。　簡略化するために規則性がないか要検討
-    if @test.results.blank?
-      if @test.details.count == 1
-        @patterns = ["1", "2"]
-      elsif @test.details.count == 2
-        @patterns = ["11", "12", "2"]
-      elsif @test.details.count == 3
-        @patterns = ["11", "12", "21", "22"]
-      elsif @test.details.count == 4
-        @patterns = ["111","112", "12", "21", "22"]
-      elsif @test.details.count == 5
-        @patterns = ["111","112", "121", "122", "21", "22"]
-      elsif @test.details.count == 6
-        @patterns = ["111","112", "121", "122", "211", "212", "22"]
-      elsif @test.details.count == 7
-        @patterns = ["111","112", "121", "122", "211", "212", "221", "222"]
-      end
-
-      #一つの診断結果を複数の解答順で使いまわせるように配列で保存したい
-      #苦肉の策としてeditで続きをすることに
-      redirect_to edit_admins_test_path(id: @test.id, patterns: @patterns)
-
-    #念の為
     else
-      redirect_to admins_tests_path(@test)
+      @test = Test.new(tests_params)
+      binding.pry
+      @test.save!
+      binding.pry
     end
+
+    #診断結果の中身が存在しているか確認して、なければdetailから解答順がいくつあるか計算。簡略化するために規則性がないか要検討
+    if @test.details.count == 1
+      @patterns = ["1", "2"]
+    elsif @test.details.count == 2
+      @patterns = ["11", "12", "2"]
+    elsif @test.details.count == 3
+      @patterns = ["11", "12", "21", "22"]
+    elsif @test.details.count == 4
+      @patterns = ["111","112", "12", "21", "22"]
+    elsif @test.details.count == 5
+      @patterns = ["111","112", "121", "122", "21", "22"]
+    elsif @test.details.count == 6
+      @patterns = ["111","112", "121", "122", "211", "212", "22"]
+    elsif @test.details.count == 7
+      @patterns = ["111","112", "121", "122", "211", "212", "221", "222"]
+    end
+
+binding.pry
+      #一つの診断結果を複数の解答順で使いまわせるように配列で保存したい
+      #苦肉の策：edit共有
+      redirect_to edit_admins_test_path(id: @test.id, patterns: @patterns)
   end
 
   def update

--- a/app/views/admins/details/_result_quiz.html.erb
+++ b/app/views/admins/details/_result_quiz.html.erb
@@ -18,9 +18,6 @@
       <li>
         <p class="text-right"><%= link_to "戻る", admins_test_path(@test.id), data: {"turbolinks" => false} %></p>
       </li>
-      <li>
-        <%= render partial: "assessments/reviewform", locals: {test: @test, assessment: @assessment} %>
-      </li>
     </ul>
   </div>
 
@@ -29,6 +26,3 @@
     <%= render partial: "assessments/test_review", locals: {test: @test} %>
   </div>
 </div>
-
-公開する（公開ステータスおん）
-削除するデストローイ

--- a/app/views/admins/tests/_form.html.erb
+++ b/app/views/admins/tests/_form.html.erb
@@ -1,5 +1,5 @@
-<%= form_with model: test, url: admins_tests_path, local: false do |f| %>
-  <div class="row" align="center">
+<%= form_with model: test, url: admins_tests_path, method: :post, local: false do |f| %>
+  <div class="row">
     <div class="col-5">
       <%= attachment_image_tag test, :image, size: "280x190",format: 'jpeg',fallback: "no_image.jpg"  %>
       <%= f.attachment_field :image, class: "image btn-lg" %>
@@ -43,6 +43,7 @@
   <i class="fa fa-plus-square" aria-hidden="true">
     <%= link_to_add_association "追加", f, :details %>
   </i>
+
 
 <!--　@detailsを保存したのちに解答順が何パターンあるか計算して選べるようにするため一度保存する -->
   <div>

--- a/app/views/admins/tests/_result_fields.html.erb
+++ b/app/views/admins/tests/_result_fields.html.erb
@@ -17,7 +17,7 @@
   <div class="form-group">
   <%= f.label :pattern, "どの解答順がこの結果に繋がりますか？" %>
 
-    <!--　@detailsを保存したのちに解答順が何パターンあるか計算して選べるようにする -->
+    <!--　newページからcreateアクションで@detailsを保存したのちに解答順が何パターンあるか計算してチェックボックスで表示 -->
   <% if @patterns.present? %>
     <% @patterns.each do |pattern| %>
 

--- a/app/views/admins/tests/edit.html.erb
+++ b/app/views/admins/tests/edit.html.erb
@@ -1,71 +1,31 @@
 <div class="container">
   <%= render "admins/tops/header" %>
   <div class="row">
-  <h3 class="admins_index">診断編集</h3>
-</div>
-<!-- request.refererで遷移元から_formのpathを変えれないか検討 -->
+    <h3 class="admins_index">診断編集</h3>
+  </div>
 
-<div class="row">
-<%= form_with model: @test, url: admins_test_path(@test), local: false do |f| %>
-  <div class="row" align="center">
-    <div class="col-5">
-      <%= attachment_image_tag @test, :image, size: "280x190",format: 'jpeg',fallback: "no_image.jpg"  %>
-      <%= f.attachment_field :image, class: "image btn-lg" %>
+<!-- 診断詳細新規作成フォーム、だけど質問数の変更による解答順の変動に対応するために流用（コードを増やしたくなかった） -->
+  <%= render "admins/tests/form", test: @test, detail: @details, categories: @categories, patterns: @patterns %>
+
+<!-- 診断結果フォーム -->
+  <%= form_with model: @test, url: admins_test_path(@test), local: false do |f| %>
+    <div class="admins_index">
+      <h3>診断結果</h3>
+      <i>(質問を増やしたら必ず解答順を計算するボタンを押しましょう)</i>
     </div>
-  </div>
-
-<!-- 診断の説明 -->
-  <div class="row">
-    <div class="col">
-      <div class="form-group">
-        <%= f.label :title, "診断名" %>
-        <%= f.text_field :title, class: "form-control" %>
+    <div class="row">
+      <div class="col">
+        <%= f.fields_for :results do |result| %>
+          <%= render "result_fields", f: result %>
+        <% end %>
       </div>
-
-      <div class="form-group">
-        <%= f.label :disclose, "公開ステータス" %>
-        <%= f.select :disclose, {"公開":"disclose", "非公開":"close"} %>
-      </div>
-
-      <div class="form-group">
-        <%= f.label :category, "ジャンル" %>
-        <%= f.collection_select :category_id, @categories, :id, :name, prompt: "--選択して下さい--"  %>
-      </div>
-
-      <div class="form-group">
-        <%= f.label :caption, "診断説明文" %>
-        <%= f.text_area :caption, rows: "8", class: "form-control"  %>
-      </div>
-
     </div>
-  </div>
+    <i class="fa fa-plus-square" aria-hidden="true">
+      <%= link_to_add_association "追加", f, :results %>
+    </i>
 
-  <h3 class="admins_index">質問(7つまで)</h3>
-  <div class="row">
-    <div class="col">
-      <%= f.fields_for :details do |detail| %>
-        <%= render "detail_fields", f: detail %>
-      <% end %>
+    <div>
+      <%= f.submit "プレビュー" %>
     </div>
-  </div>
-  <i class="fa fa-plus-square" aria-hidden="true">
-    <%= link_to_add_association "追加", f, :details %>
-  </i>
-
-  <h3 class="admins_index">診断結果</h3>
-  <div class="row">
-    <div class="col">
-      <%= f.fields_for :results do |result| %>
-        <%= render "result_fields", f: result %>
-      <% end %>
-    </div>
-  </div>
-  <i class="fa fa-plus-square" aria-hidden="true">
-    <%= link_to_add_association "追加", f, :results %>
-  </i>
-
-  <div>
-    <%= f.submit "プレビュー" %>
-  </div>
-<% end %>
+  <% end %>
 </div>

--- a/app/views/admins/tests/index.html.erb
+++ b/app/views/admins/tests/index.html.erb
@@ -23,7 +23,7 @@
             <%= link_to "#{test.title}", admins_test_path(id: test.id), data: {"turbolinks" => false} %>
           </td>
           <td>
-            <%= test.category %>
+            <%= test.category.name %>
           </td>
           <td>
             <div id="star-rate-<%= test.id %>"></div>

--- a/app/views/admins/tests/new.html.erb
+++ b/app/views/admins/tests/new.html.erb
@@ -1,8 +1,7 @@
 <div class="container">
   <%= render "admins/tops/header" %>
-  <div class="row">
   <h3 class="admins_index">診断新規投稿</h3>
-</div>
-<div class="row">
-  <%= render "admins/tests/form", test: @test, detail: @details, result: @results, categories: @categories, patterns: @patterns %>
+
+<!-- 診断詳細新規作成フォーム -->
+  <%= render "admins/tests/form", test: @test, detail: @details, categories: @categories, patterns: @patterns %>
 </div>


### PR DESCRIPTION
#管理者の診断投稿フォーム
-編集するときに質問数を増やしても解答順が更新されず、編集結果を保存できなかったエラーを新規投稿のフォームの解答順を計算するボタンを再計算ボタンとして対応

#細々と
-管理者側にコメントフォームが残っていたので削除
-診断一覧のジャンルを表示